### PR TITLE
Add cacheKey and cache handling to AfterMath init method

### DIFF
--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -36,8 +36,8 @@ public class AftermathController: SpotsController, CommandProducer {
     ComponentReloadMixin(commandType: T.self).extend(self)
   }
 
-  public convenience init<T: Command where T.Output == [ViewModel]>(spots: [Spotable], spotCommand: T, mixins: [Mixin] = []) {
-    self.init(spots: spots, initialCommand: spotCommand, mixins: mixins)
+  public convenience init<T: Command where T.Output == [ViewModel]>(cacheKey: String? = nil, spots: [Spotable], spotCommand: T, mixins: [Mixin] = []) {
+    self.init(cacheKey: cacheKey, spots: spots, initialCommand: spotCommand, mixins: mixins)
     SpotReloadMixin(index: 0, commandType: T.self).extend(self)
   }
 


### PR DESCRIPTION
This PR refactors the `AftermathController` init method to include a cache key. And to handle the case where there is already a cache in place.
