### PR TITLE
Feature/features on aftermath controller

### DIFF
--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -76,7 +76,6 @@ public class AftermathController: SpotsController, CommandProducer {
 
   public override func viewDidLoad() {
     super.viewDidLoad()
-
     toggle(features: enabledFeatures)
   }
 

--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -20,6 +20,9 @@ public class AftermathController: SpotsController, CommandProducer {
 
   public var refreshMode: AfterMathRefreshMode = .OnlyWhenEmpty
   public var refreshOnViewDidAppear: Bool = true
+  public var enabledFeatures: [SpotsFeature] = [.PullToRefresh] {
+    didSet { toggle(features: enabledFeatures) }
+  }
 
   public var errorHandler: ((error: ErrorType) -> Void)?
 

--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -101,7 +101,7 @@ public class AftermathController: SpotsController, CommandProducer {
     for feature in SpotsFeature.allValues {
       switch feature {
       case .PullToRefresh:
-        self.spotsRefreshDelegate = features.contains(feature) ? self : nil
+        spotsRefreshDelegate = features.contains(feature) ? self : nil
       }
     }
   }

--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -76,7 +76,8 @@ public class AftermathController: SpotsController, CommandProducer {
 
   public override func viewDidLoad() {
     super.viewDidLoad()
-    spotsRefreshDelegate = self
+
+    toggle(features: enabledFeatures)
   }
 
   public override func viewWillAppear(animated: Bool) {

--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -92,6 +92,15 @@ public class AftermathController: SpotsController, CommandProducer {
       $0.disposeAll()
     }
   }
+
+  func toggle(features features: [SpotsFeature]) {
+    for feature in SpotsFeature.allValues {
+      switch feature {
+      case .PullToRefresh:
+        self.spotsRefreshDelegate = features.contains(feature) ? self : nil
+      }
+    }
+  }
 }
 
 extension AftermathController: SpotsRefreshDelegate {

--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -28,7 +28,7 @@ public class AftermathController: SpotsController, CommandProducer {
 
   // MARK: - Initialization
 
-  public required init(cacheKey: String? = nil, spots: [Spotable] = [], initialCommand: AnyCommand? = nil, behaviors: [Behavior] = []) {
+  public required init(cacheKey: String? = nil, spots: [Spotable] = [], initialCommand: AnyCommand? = nil, behaviors: [Behavior] = [], features: [SpotsFeature] = SpotsFeature.allValues) {
     var stateCache: SpotCache? = nil
     var cachedSpots: [Spotable] = spots
     if let cacheKey = cacheKey {
@@ -41,6 +41,9 @@ public class AftermathController: SpotsController, CommandProducer {
     super.init()
     self.stateCache = stateCache
     self.spots = cachedSpots
+
+    enabledFeatures = features
+    toggle(features: enabledFeatures)
 
     for behavior in behaviors {
       behavior.extend(self)

--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -41,9 +41,7 @@ public class AftermathController: SpotsController, CommandProducer {
     super.init()
     self.stateCache = stateCache
     self.spots = cachedSpots
-
-    enabledFeatures = features
-    toggle(features: enabledFeatures)
+    self.enabledFeatures = features
 
     for behavior in behaviors {
       behavior.extend(self)

--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -7,6 +7,12 @@ public enum AfterMathRefreshMode {
   case Always, OnlyWhenEmpty, Disabled
 }
 
+public enum SpotsFeature {
+  case PullToRefresh
+
+  static let allValues = [PullToRefresh]
+}
+
 public class AftermathController: SpotsController, CommandProducer {
 
   let initialCommand: AnyCommand?

--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -31,6 +31,7 @@ public class AftermathController: SpotsController, CommandProducer {
   public required init(cacheKey: String? = nil, spots: [Spotable] = [], initialCommand: AnyCommand? = nil, behaviors: [Behavior] = [], features: [SpotsFeature] = SpotsFeature.allValues) {
     var stateCache: SpotCache? = nil
     var cachedSpots: [Spotable] = spots
+
     if let cacheKey = cacheKey {
       stateCache = SpotCache(key: cacheKey)
       cachedSpots = Parser.parse(stateCache!.load())


### PR DESCRIPTION
This PR adds `enabledFeatures` to `AftermathController` so that you can enable and disable some of the `Spots` related features that you get with `AftermathController`.
