### PR TITLE
Migrate/to new version of brick

### DIFF
--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -54,7 +54,7 @@ public class AftermathController: SpotsController, CommandProducer {
     ComponentReloadBehavior(commandType: T.self).extend(self)
   }
 
-  public convenience init<T: Command where T.Output == [ViewModel]>(cacheKey: String? = nil, spots: [Spotable], spotCommand: T, behaviors: [Behavior] = []) {
+  public convenience init<T: Command where T.Output == [Item]>(cacheKey: String? = nil, spots: [Spotable], spotCommand: T, behaviors: [Behavior] = []) {
     self.init(cacheKey: cacheKey, spots: spots, initialCommand: spotCommand, behaviors: behaviors)
     SpotReloadBehavior(index: 0, commandType: T.self).extend(self)
   }

--- a/Sources/Behaviors/SpotBehaviors.swift
+++ b/Sources/Behaviors/SpotBehaviors.swift
@@ -4,7 +4,7 @@ import Brick
 
 // MARK: - Reload spots
 
-public struct SpotReloadBehavior<T: Command where T.Output == [ViewModel]>: Behavior {
+public struct SpotReloadBehavior<T: Command where T.Output == [Item]>: Behavior {
 
   public let index: Int
   public let commandType: T.Type
@@ -38,7 +38,7 @@ public struct SpotInsertBehavior<T: Command where T.Output == Insert>: Behavior 
 
 // MARK: - Update view model at index
 
-public struct SpotUpdateBehavior<T: Command where T.Output == ViewModel>: Behavior {
+public struct SpotUpdateBehavior<T: Command where T.Output == Item>: Behavior {
 
   public let index: Int
   public let commandType: T.Type
@@ -55,7 +55,7 @@ public struct SpotUpdateBehavior<T: Command where T.Output == ViewModel>: Behavi
 
 // MARK: - Delete view model at index
 
-public struct SpotDeleteBehavior<T: Command where T.Output == ViewModel>: Behavior {
+public struct SpotDeleteBehavior<T: Command where T.Output == Item>: Behavior {
 
   public let index: Int
   public let commandType: T.Type

--- a/Sources/Reactions/ComponentReactions.swift
+++ b/Sources/Reactions/ComponentReactions.swift
@@ -14,7 +14,12 @@ public struct ComponentReloadBuilder: ReactionBuilder {
 
   private func stopReloading() {
     if self.controller?.refreshControl.refreshing == true {
-      delay(0.1) { self.controller?.refreshControl.endRefreshing() }
+      dispatch_after(
+        dispatch_time(DISPATCH_TIME_NOW, Int64(0.1 * Double(NSEC_PER_SEC))),
+        dispatch_get_main_queue()
+      ) {
+        self.controller?.refreshControl.endRefreshing()
+      }
     }
   }
 

--- a/Sources/Reactions/ComponentReactions.swift
+++ b/Sources/Reactions/ComponentReactions.swift
@@ -1,6 +1,5 @@
 import Spots
 import Aftermath
-import Sugar
 
 // MARK: - Reload components
 

--- a/Sources/Reactions/SpotReactions.swift
+++ b/Sources/Reactions/SpotReactions.swift
@@ -14,12 +14,12 @@ public struct SpotReloadBuilder: ReactionBuilder {
     self.controller = controller
   }
 
-  public func buildReaction() -> Reaction<[ViewModel]> {
+  public func buildReaction() -> Reaction<[Item]> {
     return Reaction(
       wait: {
         self.controller?.refreshControl.beginRefreshing()
       },
-      consume: { (viewModels: [ViewModel]) in
+      consume: { (viewModels: [Item]) in
         self.controller?.spot(self.index, Spotable.self)?.reloadIfNeeded(viewModels)
         self.controller?.refreshControl.endRefreshing()
       },
@@ -34,9 +34,9 @@ public struct SpotReloadBuilder: ReactionBuilder {
 // MARK: - Insert view model
 
 public enum Insert {
-  case Append([ViewModel])
-  case Prepend([ViewModel])
-  case Index(Int, ViewModel)
+  case Append([Item])
+  case Prepend([Item])
+  case Index(Int, Item)
 }
 
 public struct SpotInsertBuilder: ReactionBuilder {
@@ -82,9 +82,9 @@ public struct SpotUpdateBuilder: ReactionBuilder {
     self.controller = controller
   }
 
-  public func buildReaction() -> Reaction<ViewModel> {
+  public func buildReaction() -> Reaction<Item> {
     return Reaction(
-      consume: { (viewModel: ViewModel) in
+      consume: { (viewModel: Item) in
         guard let items = self.controller?.spot(self.index, Spotable.self)?.items,
           itemIndex = items.indexOf({ $0.identifier == viewModel.identifier })
           else { return }
@@ -110,9 +110,9 @@ public struct SpotDeleteBuilder: ReactionBuilder {
     self.controller = controller
   }
 
-  public func buildReaction() -> Reaction<ViewModel> {
+  public func buildReaction() -> Reaction<Item> {
     return Reaction(
-      consume: { (viewModel: ViewModel) in
+      consume: { (viewModel: Item) in
         guard let items = self.controller?.spot(self.index, Spotable.self)?.items,
           itemIndex = items.indexOf({ $0.identifier == viewModel.identifier })
           else { return }


### PR DESCRIPTION
This PR migrates to the new version of Brick. Instead of `ViewModel`, we use `Item`.
