### PR TITLE
Change class to be open

### DIFF
--- a/Sources/AftermathController.swift
+++ b/Sources/AftermathController.swift
@@ -13,7 +13,7 @@ public enum SpotsFeature {
   static let allValues = [PullToRefresh]
 }
 
-public class AftermathController: Spots.Controller, CommandProducer {
+open class AftermathController: Spots.Controller, CommandProducer {
 
   let initialCommand: AnyCommand?
   var behaviors = [Behavior]()


### PR DESCRIPTION
This PR changes the access on `AftermathController` to be open. So that you can extend the controller with your own subclass.