### PR TITLE
Use different compare to reloadIfNeeded and call spotsDidReloadComponents

### DIFF
--- a/Sources/Reactions/ComponentReactions.swift
+++ b/Sources/Reactions/ComponentReactions.swift
@@ -38,7 +38,12 @@ public struct ComponentReloadBuilder: ReactionBuilder {
       },
       consume: { (components: [Component]) in
         guard self.controller?.refreshOnViewDidAppear == true else { return }
-        self.controller?.reloadIfNeeded(components) {
+
+        self.controller?.reloadIfNeeded(components, compare: { $0 != $1 }) {
+          if let controller = self.controller as? Spots.Controller {
+            Spots.Controller.spotsDidReloadComponents?(controller)
+          }
+
           self.controller?.cache()
         }
         self.stopReloading()


### PR DESCRIPTION
This PR implements functionality around `spotsDidReloadComponents` from `Spots`.

Invoke `spotsDidReloadComponents` will be invoked inside `ComponentReactions` so that you can use the feature when building component models.