### PR TITLE
Remove calling `.cache`

### DIFF
--- a/Sources/Reactions/ComponentReactions.swift
+++ b/Sources/Reactions/ComponentReactions.swift
@@ -40,7 +40,6 @@ public struct ComponentReloadBuilder: ReactionBuilder {
 
         controller.reloadIfNeeded(components, compare: controller.viewModelComparison) {
           Spots.Controller.spotsDidReloadComponents?(controller)
-          controller.cache()
         }
         self.stopReloading()
     },


### PR DESCRIPTION
This PR removes the call to `cache`. This is handeld internally by Spots.